### PR TITLE
Update PS script: Support x86 arch, more robust Path logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,13 @@ curl -fsSL https://raw.githubusercontent.com/hounddogai/hounddog/main/install.sh
 
 ### Windows
 
-To install the standalone executable at `%LocalAppData%\hounddog\bin\hounddog.exe` (in PowerShell):
+To install in user directory at `%LocalAppData%\hounddog\bin\hounddog.exe`:
+
+```powershell
+irm https://raw.githubusercontent.com/hounddogai/hounddog/main/install.ps1 | iex
+```
+
+To install system-wide at `C:\Program Files\hounddog\bin\hounddog.exe`, run the same command in an elevated PowerShell session (run as administrator):
 
 ```powershell
 irm https://raw.githubusercontent.com/hounddogai/hounddog/main/install.ps1 | iex
@@ -61,8 +67,7 @@ irm https://raw.githubusercontent.com/hounddogai/hounddog/main/install.ps1 | iex
 
 ### Manual Download
 
-Download the standalone binary and checksum files directly from our
-[releases page](https://github.com/hounddogai/hounddog/releases).
+Download the standalone binary from our [releases page](https://github.com/hounddogai/hounddog/releases). 
 
 ## Usage
 
@@ -149,10 +154,16 @@ sudo rm /usr/local/bin/hounddog
 
 ### Windows
 
-If installed at `%LocalAppData%\hounddog\bin\hounddog.exe`:
+If installed in user directory at `%LocalAppData%\hounddog\bin\hounddog.exe`:
 
 ```powershell
-Remove-Item -Recurse -Force $env:LocalAppData\hounddog
+Remove-Item -Recurse -Force "$env:LocalAppData\hounddog"
+```
+
+If installed system-wide, run in elevated PowerShell session (run as administrator):
+
+```powershell
+Remove-Item -Recurse -Force "$env:ProgramFiles\hounddog"
 ```
 
 ## Use Cases

--- a/install.ps1
+++ b/install.ps1
@@ -8,8 +8,6 @@ $ErrorActionPreference = 'Stop'
 # Disable progress bar for faster downloads.
 $ProgressPreference = 'SilentlyContinue'
 
-Write-Host "Installing HoundDog CLI..."
-
 # Check CPU architecture.
 $Arch = switch ($env:PROCESSOR_ARCHITECTURE) {
     'AMD64' { 'amd64' }
@@ -21,8 +19,23 @@ $DownloadUrl = "https://github.com/hounddogai/hounddog/releases/latest/download/
 $TempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
 
 try {
-    # Set up the binary installation directory.
-    $InstallPath = Join-Path ([Environment]::GetFolderPath('LocalApplicationData')) 'HoundDog\bin'
+    # Determine if running with admin privileges
+    $IsAdmin = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+    # Set installation path and PATH scope based on privileges
+    if ($IsAdmin) {
+        # Admin: Install to Program Files and update System PATH
+        $InstallPath = Join-Path $env:ProgramFiles "hounddog\bin"
+        $PathScope = "Machine"
+        Write-Host "Installing HoundDog CLI for all users..."
+    } else {
+        # Non-admin: Install to user's local app data and update User PATH
+        $InstallPath = Join-Path ([Environment]::GetFolderPath('LocalApplicationData')) 'hounddog\bin'
+        $PathScope = "User"
+        Write-Host "Installing HoundDog CLI for current user only..."
+    }
+
+    # Create the installation directory if it doesn't exist
     if (Test-Path $InstallPath) {
         Remove-Item -Path "$InstallPath\*" -Force -Recurse -ErrorAction SilentlyContinue
     } else {
@@ -34,7 +47,7 @@ try {
 
     # Download and extract the ZIP archive to the installation directory.
     $ZipPath = Join-Path $TempDir 'hounddog.zip'
-    Write-Host "Downloading HoundDog CLI from $DownloadUrl ..."
+    Write-Host "Downloading ZIP from $DownloadUrl ..."
     Invoke-WebRequest -Uri $DownloadUrl -OutFile $ZipPath -UseBasicParsing
     Write-Host "Extracting ZIP to $InstallPath ..."
     Expand-Archive -Path $ZipPath -DestinationPath $InstallPath -Force
@@ -57,42 +70,38 @@ try {
     if ($ActualHash -ne $ExpectedHash) {
         throw "Checksum verification failed."
     }
-    Write-Host "Checksum verification successful."
 
-    # Get the current user PATH and split it by semicolon.
-    # Filter out any empty entries and trim whitespace.
-    # Use [System.Environment]::GetEnvironmentVariable with a safety check for null.
-    $CurrentUserPaths = @()
-    $RawUserPath = [System.Environment]::GetEnvironmentVariable('Path', 'User')
-    if ($RawUserPath) {
-        $CurrentUserPaths = $RawUserPath -split ';' | Where-Object { $_.Trim() -ne "" } | ForEach-Object { $_.Trim() }
-    }
+    # Update PATH based on admin status
+    $CurrentPath = [System.Environment]::GetEnvironmentVariable('Path', $PathScope)
 
-    # Create a new array for the updated PATH.
-    $UpdatedPathsArray = New-Object System.Collections.Generic.List[string]
-
-    # Add existing unique paths to the list.
-    foreach ($pathEntry in $CurrentUserPaths) {
-        if (-not $UpdatedPathsArray.Contains($pathEntry)) {
-            $UpdatedPathsArray.Add($pathEntry)
+    # Only add the HoundDog installation path if it's not already in the PATH
+    if ($CurrentPath -notlike "*$InstallPath*") {
+        # Ensure PATH ends with semicolon before appending
+        if ($CurrentPath -and -not $CurrentPath.EndsWith(';')) {
+            $CurrentPath = "$CurrentPath;"
         }
+        
+        # Add the new path
+        $NewPath = "$CurrentPath$InstallPath"
+        
+        try {
+            [Environment]::SetEnvironmentVariable('Path', $NewPath, $PathScope)
+            Write-Host "Added HoundDog CLI to $PathScope PATH."
+        } catch {
+            Write-Host "Failed to update $PathScope PATH: $_" -ForegroundColor Red
+            exit 1
+        }
+    } else {
+        $NewPath = $CurrentPath
     }
 
-    # Add the HoundDog installation path if it's not already there.
-    if (-not $UpdatedPathsArray.Contains($InstallPath)) {
-        $UpdatedPathsArray.Add($InstallPath)
-    }
-
-    # Join the unique paths with a semicolon.
-    $NewPath = ($UpdatedPathsArray | Where-Object { $_ -ne $null -and $_ -ne '' }) -join ';'
-
-    [Environment]::SetEnvironmentVariable('Path', $NewPath, 'User')
+    # Update current session's PATH
+    $env:Path = $NewPath
 
     # Test installation.
-    $env:Path = $NewPath
     if (Get-Command hounddog -ErrorAction SilentlyContinue) {
         Write-Host "`nHoundDog CLI installed successfully."
-        Write-Host "Run 'hounddog --help' to get started. You may need to restart your terminal first."
+        Write-Host "Run 'hounddog --help' to get started."
     } else {
         throw "Cannot find 'hounddog' command in PATH."
     }

--- a/install.ps1
+++ b/install.ps1
@@ -14,67 +14,50 @@ Write-Host "Installing HoundDog CLI..."
 $Arch = switch ($env:PROCESSOR_ARCHITECTURE) {
     'AMD64' { 'amd64' }
     'ARM64' { 'arm64' }
-    'x86' { 'amd64' } # Treat x86 as amd64 for download purposes
+    'x86' { 'amd64' }
     default { throw 'Unsupported CPU architecture. HoundDog CLI requires an AMD64, ARM64, or x86 processor.' }
 }
-Write-Host "Detected architecture: $($env:PROCESSOR_ARCHITECTURE), using download architecture: $Arch"
 $DownloadUrl = "https://github.com/hounddogai/hounddog/releases/latest/download/hounddog-windows-$Arch.zip"
-Write-Host "Download URL: $DownloadUrl"
 $TempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
-Write-Host "Temporary directory: $TempDir"
-
 
 try {
     # Set up the binary installation directory.
     $InstallPath = Join-Path ([Environment]::GetFolderPath('LocalApplicationData')) 'HoundDog\bin'
-    Write-Host "Installation path: $InstallPath"
     if (Test-Path $InstallPath) {
-        Write-Host "Removing existing HoundDog binaries..."
         Remove-Item -Path "$InstallPath\*" -Force -Recurse -ErrorAction SilentlyContinue
     } else {
-        Write-Host "Creating installation directory..."
         New-Item -ItemType Directory -Path $InstallPath -Force | Out-Null
     }
 
     # Create a temporary directory for downloading the ZIP archive.
-    Write-Host "Creating temporary download directory..."
-    New-Item -ItemType Directory -Path $TempDir -Force | Out-Null # Added -Force just in case
+    New-Item -ItemType Directory -Path $TempDir -Force | Out-Null
 
     # Download and extract the ZIP archive to the installation directory.
     $ZipPath = Join-Path $TempDir 'hounddog.zip'
-    Write-Host "Downloading ZIP from $DownloadUrl to $ZipPath..."
+    Write-Host "Downloading HoundDog CLI from $DownloadUrl ..."
     Invoke-WebRequest -Uri $DownloadUrl -OutFile $ZipPath -UseBasicParsing
-    Write-Host "Download complete. Extracting ZIP to $InstallPath..."
+    Write-Host "Extracting ZIP to $InstallPath ..."
     Expand-Archive -Path $ZipPath -DestinationPath $InstallPath -Force
 
-    Write-Host "Verifying extracted files in $InstallPath..."
+    # Verify the extracted file.
     $ExtractedFiles = Get-ChildItem -Path $InstallPath -ErrorAction SilentlyContinue
     if ($ExtractedFiles.Count -eq 0) {
-        throw "No files found in $InstallPath after extraction. ZIP structure might be unexpected or extraction failed."
+        throw "No files found in $InstallPath after extraction."
     }
-    Write-Host "Files found after extraction:"
-    $ExtractedFiles | ForEach-Object { Write-Host "  $($_.Name)" }
-
-    # Check specifically for hounddog.exe
     if (-not (Test-Path (Join-Path $InstallPath 'hounddog.exe'))) {
-        throw "hounddog.exe not found directly in $InstallPath after extraction. Please check the ZIP file structure."
+        throw "hounddog.exe not found in $InstallPath after extraction."
     }
 
-    # Download the SHA256 checksum file and verify the integrity of the ZIP archive.
+    # Download the SHA256 checksum file and verify the integrity of the binary.
+    Write-Host "Verifying checksum ..."
     $ChecksumPath = Join-Path $TempDir 'hounddog.zip.sha256'
-    Write-Host "Downloading SHA256 checksum from $DownloadUrl.sha256 to $ChecksumPath..."
     Invoke-WebRequest -Uri "$DownloadUrl.sha256" -OutFile $ChecksumPath -UseBasicParsing
     $ExpectedHash = (Get-Content -Path $ChecksumPath).Split(' ')[0] # Get only the hash, sometimes files include filename
     $ActualHash = Get-FileHash -Path $ZipPath -Algorithm SHA256 | Select-Object -ExpandProperty Hash
-    Write-Host "Expected Hash: $ExpectedHash"
-    Write-Host "Actual Hash:   $ActualHash"
     if ($ActualHash -ne $ExpectedHash) {
-        throw "Checksum verification failed. Downloaded file might be corrupted."
+        throw "Checksum verification failed."
     }
     Write-Host "Checksum verification successful."
-
-    # Update PATH environment variable (user).
-    Write-Host "Updating User PATH environment variable..."
 
     # Get the current user PATH and split it by semicolon.
     # Filter out any empty entries and trim whitespace.
@@ -88,28 +71,25 @@ try {
     # Create a new array for the updated PATH.
     $UpdatedPathsArray = New-Object System.Collections.Generic.List[string]
 
-    # Add existing unique paths to the list
+    # Add existing unique paths to the list.
     foreach ($pathEntry in $CurrentUserPaths) {
         if (-not $UpdatedPathsArray.Contains($pathEntry)) {
             $UpdatedPathsArray.Add($pathEntry)
         }
     }
 
-    # Add the HoundDog installation path if it's not already there
+    # Add the HoundDog installation path if it's not already there.
     if (-not $UpdatedPathsArray.Contains($InstallPath)) {
         $UpdatedPathsArray.Add($InstallPath)
     }
 
-    # Join the unique paths with a semicolon
+    # Join the unique paths with a semicolon.
     $NewPath = ($UpdatedPathsArray | Where-Object { $_ -ne $null -and $_ -ne '' }) -join ';'
 
     [Environment]::SetEnvironmentVariable('Path', $NewPath, 'User')
-    Write-Host "User PATH updated. New Path: $NewPath"
 
     # Test installation.
-    Write-Host "Updating current session's PATH for testing..."
     $env:Path = $NewPath
-    Write-Host "Attempting to find 'hounddog' command..."
     if (Get-Command hounddog -ErrorAction SilentlyContinue) {
         Write-Host "`nHoundDog CLI installed successfully."
         Write-Host "Run 'hounddog --help' to get started. You may need to restart your terminal first."
@@ -122,7 +102,6 @@ try {
 } finally {
     # Clean up the temporary directory.
     if (Test-Path $TempDir) {
-        Write-Host "Cleaning up temporary directory: $TempDir"
         Remove-Item -Path $TempDir -Recurse -Force -ErrorAction SilentlyContinue
     }
 }

--- a/install.ps1
+++ b/install.ps1
@@ -14,51 +14,107 @@ Write-Host "Installing HoundDog CLI..."
 $Arch = switch ($env:PROCESSOR_ARCHITECTURE) {
     'AMD64' { 'amd64' }
     'ARM64' { 'arm64' }
-    default { throw 'Unsupported CPU architecture. HoundDog CLI requires a AMD64 or ARM64 processor.' }
+    'x86' { 'amd64' } # Treat x86 as amd64 for download purposes
+    default { throw 'Unsupported CPU architecture. HoundDog CLI requires an AMD64, ARM64, or x86 processor.' }
 }
+Write-Host "Detected architecture: $($env:PROCESSOR_ARCHITECTURE), using download architecture: $Arch"
 $DownloadUrl = "https://github.com/hounddogai/hounddog/releases/latest/download/hounddog-windows-$Arch.zip"
+Write-Host "Download URL: $DownloadUrl"
 $TempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+Write-Host "Temporary directory: $TempDir"
 
 
 try {
     # Set up the binary installation directory.
     $InstallPath = Join-Path ([Environment]::GetFolderPath('LocalApplicationData')) 'HoundDog\bin'
+    Write-Host "Installation path: $InstallPath"
     if (Test-Path $InstallPath) {
-        Remove-Item -Path $InstallPath\* -Force -Recurse -ErrorAction SilentlyContinue
+        Write-Host "Removing existing HoundDog binaries..."
+        Remove-Item -Path "$InstallPath\*" -Force -Recurse -ErrorAction SilentlyContinue
     } else {
+        Write-Host "Creating installation directory..."
         New-Item -ItemType Directory -Path $InstallPath -Force | Out-Null
     }
 
     # Create a temporary directory for downloading the ZIP archive.
-    New-Item -ItemType Directory -Path $TempDir | Out-Null
+    Write-Host "Creating temporary download directory..."
+    New-Item -ItemType Directory -Path $TempDir -Force | Out-Null # Added -Force just in case
 
     # Download and extract the ZIP archive to the installation directory.
     $ZipPath = Join-Path $TempDir 'hounddog.zip'
+    Write-Host "Downloading ZIP from $DownloadUrl to $ZipPath..."
     Invoke-WebRequest -Uri $DownloadUrl -OutFile $ZipPath -UseBasicParsing
+    Write-Host "Download complete. Extracting ZIP to $InstallPath..."
     Expand-Archive -Path $ZipPath -DestinationPath $InstallPath -Force
+
+    Write-Host "Verifying extracted files in $InstallPath..."
+    $ExtractedFiles = Get-ChildItem -Path $InstallPath -ErrorAction SilentlyContinue
+    if ($ExtractedFiles.Count -eq 0) {
+        throw "No files found in $InstallPath after extraction. ZIP structure might be unexpected or extraction failed."
+    }
+    Write-Host "Files found after extraction:"
+    $ExtractedFiles | ForEach-Object { Write-Host "  $($_.Name)" }
+
+    # Check specifically for hounddog.exe
+    if (-not (Test-Path (Join-Path $InstallPath 'hounddog.exe'))) {
+        throw "hounddog.exe not found directly in $InstallPath after extraction. Please check the ZIP file structure."
+    }
 
     # Download the SHA256 checksum file and verify the integrity of the ZIP archive.
     $ChecksumPath = Join-Path $TempDir 'hounddog.zip.sha256'
+    Write-Host "Downloading SHA256 checksum from $DownloadUrl.sha256 to $ChecksumPath..."
     Invoke-WebRequest -Uri "$DownloadUrl.sha256" -OutFile $ChecksumPath -UseBasicParsing
-    $ExpectedHash = Get-Content -Path $ChecksumPath
+    $ExpectedHash = (Get-Content -Path $ChecksumPath).Split(' ')[0] # Get only the hash, sometimes files include filename
     $ActualHash = Get-FileHash -Path $ZipPath -Algorithm SHA256 | Select-Object -ExpandProperty Hash
+    Write-Host "Expected Hash: $ExpectedHash"
+    Write-Host "Actual Hash:   $ActualHash"
     if ($ActualHash -ne $ExpectedHash) {
-        throw "Checksum verification failed."
+        throw "Checksum verification failed. Downloaded file might be corrupted."
     }
+    Write-Host "Checksum verification successful."
 
     # Update PATH environment variable (user).
-    $UserPath = [Environment]::GetEnvironmentVariable('Path', 'User')
-    $Paths = $UserPath -split ';' | Where-Object { $_ -and $_ -ne $InstallPath }
-    $NewPath = ($Paths + $InstallPath) -join ';'
+    Write-Host "Updating User PATH environment variable..."
+
+    # Get the current user PATH and split it by semicolon.
+    # Filter out any empty entries and trim whitespace.
+    # Use [System.Environment]::GetEnvironmentVariable with a safety check for null.
+    $CurrentUserPaths = @()
+    $RawUserPath = [System.Environment]::GetEnvironmentVariable('Path', 'User')
+    if ($RawUserPath) {
+        $CurrentUserPaths = $RawUserPath -split ';' | Where-Object { $_.Trim() -ne "" } | ForEach-Object { $_.Trim() }
+    }
+
+    # Create a new array for the updated PATH.
+    $UpdatedPathsArray = New-Object System.Collections.Generic.List[string]
+
+    # Add existing unique paths to the list
+    foreach ($pathEntry in $CurrentUserPaths) {
+        if (-not $UpdatedPathsArray.Contains($pathEntry)) {
+            $UpdatedPathsArray.Add($pathEntry)
+        }
+    }
+
+    # Add the HoundDog installation path if it's not already there
+    if (-not $UpdatedPathsArray.Contains($InstallPath)) {
+        $UpdatedPathsArray.Add($InstallPath)
+    }
+
+    # Join the unique paths with a semicolon
+    $NewPath = ($UpdatedPathsArray | Where-Object { $_ -ne $null -and $_ -ne '' }) -join ';'
+
     [Environment]::SetEnvironmentVariable('Path', $NewPath, 'User')
+    Write-Host "User PATH updated. New Path: $NewPath"
 
     # Test installation.
+    Write-Host "Updating current session's PATH for testing..."
     $env:Path = $NewPath
+    Write-Host "Attempting to find 'hounddog' command..."
     if (Get-Command hounddog -ErrorAction SilentlyContinue) {
         Write-Host "`nHoundDog CLI installed successfully."
         Write-Host "Run 'hounddog --help' to get started. You may need to restart your terminal first."
     } else {
-        throw "Cannot find 'hounddog' command in PATH."
+        throw "Cannot find 'hounddog' command in PATH. This indicates an issue with extraction or PATH update."
     }
 } catch {
     Write-Host "$_ Aborting installation." -ForegroundColor Red
@@ -66,6 +122,7 @@ try {
 } finally {
     # Clean up the temporary directory.
     if (Test-Path $TempDir) {
+        Write-Host "Cleaning up temporary directory: $TempDir"
         Remove-Item -Path $TempDir -Recurse -Force -ErrorAction SilentlyContinue
     }
 }

--- a/install.ps1
+++ b/install.ps1
@@ -114,7 +114,7 @@ try {
         Write-Host "`nHoundDog CLI installed successfully."
         Write-Host "Run 'hounddog --help' to get started. You may need to restart your terminal first."
     } else {
-        throw "Cannot find 'hounddog' command in PATH. This indicates an issue with extraction or PATH update."
+        throw "Cannot find 'hounddog' command in PATH."
     }
 } catch {
     Write-Host "$_ Aborting installation." -ForegroundColor Red


### PR DESCRIPTION
- Support x86 architecture for now it's teh same executable for all Windows
- Make the Update System PATH logic more robust, it was not separating with semicolons before thus exe was not found
- Added More Comments